### PR TITLE
Fix PR_SHORT formatting.

### DIFF
--- a/loghub/main.py
+++ b/loghub/main.py
@@ -195,7 +195,7 @@ def format_changelog(repo,
             if output_format == 'changelog':
                 pr_link = PR_LONG.format(number=number, repo=repo)
             else:
-                pr_link = PR_SHORT.format(number)
+                pr_link = PR_SHORT.format(number=number)
             lines.append(pr_link + ' - ' + i['title'] + '\n')
     tense = 'was' if number_of_prs == 1 else 'were'
     plural = '' if number_of_prs == 1 else 's'


### PR DESCRIPTION
Thanks for putting this out there! I was just thinking of writing something myself.

When I try to generate release format notes:
```
loghub -m 0.4.1 -f release Unidata/MetPy
```
I get an error:
```pytb
Traceback (most recent call last):
  File "/Users/rmay/miniconda3/envs/py35/bin/loghub", line 6, in <module>
    sys.exit(loghub.main.main())
  File "/Users/rmay/miniconda3/envs/py35/lib/python3.5/site-packages/loghub/main.py", line 101, in main
    output_format=options.output_format, )
  File "/Users/rmay/miniconda3/envs/py35/lib/python3.5/site-packages/loghub/main.py", line 137, in create_changelog
    output_format=output_format)
  File "/Users/rmay/miniconda3/envs/py35/lib/python3.5/site-packages/loghub/main.py", line 198, in format_changelog
    pr_link = PR_SHORT.format(number)
KeyError: 'number'
```

This should fix that.