### PR TITLE
PR: Fix bug on since keyword returning incorrect issues

### DIFF
--- a/loghub/main.py
+++ b/loghub/main.py
@@ -170,11 +170,10 @@ def format_changelog(repo,
         version=version, date=close_date, q=quotes)
 
     lines.append(header)
-    lines.append('### Issues closed\n')
 
     # --- Issues
     number_of_issues = 0
-    issue_lines = ['**Issues**\n']
+    issue_lines = ['### Issues Closed\n']
     for i in issues:
         pr = i.get('pull_request', '')
         if not pr:
@@ -197,7 +196,7 @@ def format_changelog(repo,
 
     # --- Pull requests
     number_of_prs = 0
-    pr_lines = ['**Pull requests**\n']
+    pr_lines = ['### Pull Requests merged\n']
     for i in issues:
         pr = i.get('pull_request', '')
         if pr:

--- a/loghub/main.py
+++ b/loghub/main.py
@@ -19,6 +19,8 @@ import time
 # Local imports
 from loghub.external.github import GitHub
 
+PY2 = sys.version[0] == '2'
+
 # TEMPLATES
 ISSUE_LONG = "* [Issue {number}](https://github.com/{repo}/issues/{number})"
 ISSUE_SHORT = "* Issue #{number}"
@@ -168,7 +170,7 @@ def format_changelog(repo,
         version=version, date=close_date, q=quotes)
 
     lines.append(header)
-    lines.append('### Bugs fixed\n')
+    lines.append('### Issues closed\n')
 
     # --- Issues
     number_of_issues = 0
@@ -216,12 +218,20 @@ def format_changelog(repo,
 
     # Print everything
     for line in lines:
+        # Make the text file and console output identical
+        if line.endswith('\n'):
+            line = line[:-1]
         print(line)
+    print()
 
     # Write to file
+    text = ''.join(lines)
+
+    if PY2:
+        text = unicode(text).encode('utf-8')  # NOQA
+
     with open(output_file, 'w') as f:
-        for line in lines:
-            print(line, file=f)
+        f.write(text)
 
 
 class GitHubRepo(object):
@@ -304,7 +314,15 @@ class GitHubRepo(object):
             else:
                 break
 
-        # If until was provided, fix it!
+        # If since was provided, filter the issue
+        if since:
+            since_date = self.str_to_date(since)
+            for issue in issues[:]:
+                close_date = self.str_to_date(issue['closed_at'])
+                if close_date < since_date:
+                    issues.remove(issue)
+
+        # If until was provided, filter the issue
         if until:
             until_date = self.str_to_date(until)
             for issue in issues[:]:


### PR DESCRIPTION
Fixes #15 

---

## Description

The since tag was not working properly because github api when using `since` returns issues updated after that date so closed issues that had some update (like a bulk add of some tags) would result in issues closed before that date but updated after.

Now since is filtered using the close_date tag.

