### PR TITLE
PR: Add user configuration file loading (in home folder)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,5 @@ loghub.egg-info/
 
 CHANGELOG.temp
 labels.txt
+
+.pypirc

--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ CHANGELOG.temp
 labels.txt
 
 .pypirc
+.loghubrc

--- a/loghub/cli/main.py
+++ b/loghub/cli/main.py
@@ -234,20 +234,20 @@ def parse_arguments(skip=False):
         print('LOGHUB: PR label group takes 1 or 2 arguments\n')
         sys.exit(1)
 
+    github_token = options.token
+    zenhub_token = options.zenhub_token
+
     config = load_config()
     if config:
         try:
-            github_token = config['github']['token']
+            github_token = config.get('github', 'token')
         except Exception:
             github_token = options.token
 
         try:
-            zenhub_token = config['zenhub']['token']
+            zenhub_token = config.get('zenhub', 'token')
         except Exception:
             zenhub_token = options.zenhub_token
-    else:
-        github_token = options.token
-        zenhub_token = options.zenhub_token
 
     if not skip:
         create_changelog(

--- a/loghub/cli/main.py
+++ b/loghub/cli/main.py
@@ -17,6 +17,7 @@ import sys
 
 # Local imports
 from loghub.cli.common import add_common_parser_args, parse_password_check_repo
+from loghub.core.config import load_config
 from loghub.core.formatter import create_changelog
 
 # yapf: enable
@@ -233,15 +234,30 @@ def parse_arguments(skip=False):
         print('LOGHUB: PR label group takes 1 or 2 arguments\n')
         sys.exit(1)
 
+    config = load_config()
+    if config:
+        try:
+            github_token = config['github']['token']
+        except Exception:
+            github_token = options.token
+
+        try:
+            zenhub_token = config['zenhub']['token']
+        except Exception:
+            zenhub_token = options.zenhub_token
+    else:
+        github_token = options.token
+        zenhub_token = options.zenhub_token
+
     if not skip:
         create_changelog(
             repo=options.repository,
             username=username,
             password=password,
-            token=options.token,
+            token=github_token,
             milestone=milestone,
             zenhub_release=zenhub_release,
-            zenhub_token=options.zenhub_token,
+            zenhub_token=zenhub_token,
             since_tag=options.since_tag,
             until_tag=options.until_tag,
             branch=options.branch,

--- a/loghub/core/config.py
+++ b/loghub/core/config.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# Copyright (c) The Spyder Development Team
+#
+# Licensed under the terms of the MIT License
+# (See LICENSE.txt for details)
+# -----------------------------------------------------------------------------
+"""Basic config parser."""
+
+# Third party imports
+import configparser
+import os
+
+
+def user_config_path():
+    """Return the path of the Loghub user configuration file."""
+    return os.path.expanduser('~/.loghubrc')
+
+
+def load_config():
+    """Load configutration file."""
+    path = user_config_path()
+    config = configparser.ConfigParser()
+    if os.path.isfile(path):
+        config.read(path)
+
+    return config

--- a/loghub/core/config.py
+++ b/loghub/core/config.py
@@ -8,8 +8,15 @@
 """Basic config parser."""
 
 # Third party imports
-import configparser
 import os
+import sys
+
+# Constants
+PY2 = sys.version[0] == '2'
+if PY2:
+    import ConfigParser as configparser
+else:
+    import configparser
 
 
 def user_config_path():
@@ -17,11 +24,11 @@ def user_config_path():
     return os.path.expanduser('~/.loghubrc')
 
 
-def load_config():
+def load_config(path=None):
     """Load configutration file."""
-    path = user_config_path()
+    config_path = path or user_config_path()
     config = configparser.ConfigParser()
-    if os.path.isfile(path):
-        config.read(path)
+    if os.path.isfile(config_path):
+        config.read(config_path)
 
     return config

--- a/loghub/core/formatter.py
+++ b/loghub/core/formatter.py
@@ -13,6 +13,7 @@
 from collections import OrderedDict
 import codecs
 import re
+import sys
 import time
 
 # Third party imports
@@ -346,7 +347,9 @@ def create_changelog(repo=None,
                         issue['loghub_label_names'] = [l['name'] for l in issue.get('labels')]
                         issues.append(issue)
             else:
-                print("Error!")
+                release_titles = [release['title'] for release in releases]
+                print("Zenhub release not found! Available releases are: {}".format(
+                    release_titles))
                 sys.exit(1)
 
         # Filter by regex if available

--- a/loghub/tests/test_config.py
+++ b/loghub/tests/test_config.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+# -----------------------------------------------------------------------------
+# Copyright (c) The Spyder Development Team
+#
+# Licensed under the terms of the MIT License
+# (See LICENSE.txt for details)
+# -----------------------------------------------------------------------------
+"""Tests changelog labels."""
+
+# Standard library imports
+import tempfile
+
+# Third party imports
+from mock import patch
+
+# Local imports
+from loghub.core.config import load_config
+
+
+def test_load_config_empty():
+    _, tempfilepath = tempfile.mkstemp()
+
+    with patch('loghub.core.config.user_config_path',
+                return_value=tempfilepath) as method:
+        config = load_config()
+        assert config.sections() == []
+
+
+def test_load_config():
+    _, tempfilepath = tempfile.mkstemp()
+    with open(tempfilepath, 'w') as fh:
+        fh.write('[github]\ntoken=1\n[zenhub]\ntoken=2')
+
+    with patch('loghub.core.config.user_config_path',
+                return_value=tempfilepath) as method:
+        config = load_config()
+        assert config.sections() == ['github', 'zenhub']
+        assert config.get('github', 'token') == '1'
+        assert config.get('zenhub', 'token') == '2'
+
+
+def test_load_config_with_path():
+    _, tempfilepath = tempfile.mkstemp()
+    with open(tempfilepath, 'w') as fh:
+        fh.write('[github]\ntoken=1\n[zenhub]\ntoken=2')
+
+    config = load_config(tempfilepath)
+    assert config.sections() == ['github', 'zenhub']
+    assert config.get('github', 'token') == '1'
+    assert config.get('zenhub', 'token') == '2'


### PR DESCRIPTION
Fixes #111

Now we can provide a `.loghubrc` file  in the home folder with:

```ini
[github]
token = <token>

[zenhub]
token = <token>
```
